### PR TITLE
Prefer `tokio::fs::*` over `std::fs::*`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "mirrors-arch"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "futures",

--- a/crates/archlinux/Cargo.toml
+++ b/crates/archlinux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirrors-arch"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["rtkay123 <dev@kanjala.com>"]

--- a/crates/archlinux/src/lib.rs
+++ b/crates/archlinux/src/lib.rs
@@ -89,12 +89,21 @@ pub async fn get_mirrors_with_raw(
     with_timeout: Option<u64>,
 ) -> Result<(ArchLinux, String)> {
     let response = get_response(source, with_timeout).await?;
+    deserialise_mirrors(response).await
+}
 
+async fn deserialise_mirrors(response: Response) -> Result<(ArchLinux, String)> {
     let root: Root = response.json().await?;
 
     let value = serde_json::to_string(&root)?;
-
     Ok((ArchLinux::from(root), value))
+}
+
+/// The same as [get_mirrors_with_raw](get_mirrors_with_raw) but uses a specified
+/// [Client](reqwest::Client) for requests
+pub async fn get_mirrors_with_client(source: &str, client: Client) -> Result<(ArchLinux, String)> {
+    let response = client.get(source).send().await?;
+    deserialise_mirrors(response).await
 }
 
 /// Parses a `string slice` to the [ArchLinux](ArchLinux) type


### PR DESCRIPTION
Use async adapters for the `fs` module in async contexts