### PR TITLE
feat: replace `log` with `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,16 +374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,12 +796,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
-
-[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,9 +810,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru"
@@ -899,10 +880,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "systemd-journal-logger",
  "tokio",
  "toml",
  "tracing",
+ "tracing-journald",
  "tracing-subscriber",
  "tui-logger",
  "unicode-width",
@@ -1221,19 +1202,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustix"
-version = "0.38.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
-dependencies = [
- "bitflags 2.4.1",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustls"
 version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,16 +1475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "systemd-journal-logger"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65c37bfdf7a8ae8d1793cfed716088dee377cfafdb29cb6941e808cea958ba"
-dependencies = [
- "log",
- "rustix",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +1644,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-journald"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,12 +1773,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "value-bag"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +840,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,7 +893,6 @@ dependencies = [
  "crossterm",
  "dirs",
  "itertools",
- "log",
  "mirrors-arch",
  "notify",
  "ratatui",
@@ -885,6 +902,8 @@ dependencies = [
  "systemd-journal-logger",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "tui-logger",
  "unicode-width",
 ]
@@ -921,6 +940,16 @@ dependencies = [
  "mio",
  "walkdir",
  "windows-sys",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -962,6 +991,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1074,6 +1109,50 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
@@ -1288,6 +1367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1537,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,7 +1660,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1572,6 +1682,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1593,6 +1733,8 @@ dependencies = [
  "log",
  "parking_lot",
  "ratatui",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1656,6 +1798,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"

--- a/crates/mirro-rs/Cargo.toml
+++ b/crates/mirro-rs/Cargo.toml
@@ -20,7 +20,6 @@ clap = { version = "4.0.32", features = ["derive"] }
 crossterm = "0.27.0"
 dirs = "5.0.1"
 itertools = "0.11.0"
-log = "0.4.17"
 archlinux = { package = "mirrors-arch", version = "0.1.1", path = "../archlinux", features = ["time"] }
 notify = { version = "6.1.1", optional = true }
 serde = { version = "1.0.151", features = ["derive"] }
@@ -28,9 +27,11 @@ serde_json = { version = "1.0.91", optional = true }
 serde_yaml = { version = "0.9.16", optional = true }
 tokio = { version = "1.23.0", features = ["rt-multi-thread", "macros", "fs"] }
 toml = { version = "0.8.8", optional = true }
-tui-logger = { version = "0.10.0", features = ["crossterm"], default-features = false }
+tui-logger = { version = "0.10.0", features = ["crossterm", "tracing-support"], default-features = false }
 unicode-width = "0.1.10"
 ratatui = { version = "0.24.0", features = ["crossterm"], default-features = false }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 systemd-journal-logger = "2.1.0"

--- a/crates/mirro-rs/Cargo.toml
+++ b/crates/mirro-rs/Cargo.toml
@@ -33,8 +33,8 @@ ratatui = { version = "0.24.0", features = ["crossterm"], default-features = fal
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
-systemd-journal-logger = "2.1.0"
+[target.'cfg(unix)'.dependencies]
+tracing-journald = "0.3.0"
 
 [features]
 default = []

--- a/crates/mirro-rs/src/config/file.rs
+++ b/crates/mirro-rs/src/config/file.rs
@@ -3,7 +3,7 @@ use std::{io::ErrorKind, path::PathBuf};
 use std::path::Path;
 
 use itertools::Itertools;
-use log::error;
+use tracing::error;
 
 use crate::cli::ArgConfig;
 

--- a/crates/mirro-rs/src/config/watch.rs
+++ b/crates/mirro-rs/src/config/watch.rs
@@ -5,8 +5,8 @@ use std::{
     sync::{mpsc, Arc, Mutex},
 };
 
-use log::error;
 use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
+use tracing::error;
 
 use crate::config::read_config_file;
 

--- a/crates/mirro-rs/src/dbg/mod.rs
+++ b/crates/mirro-rs/src/dbg/mod.rs
@@ -8,6 +8,7 @@ pub fn log(skip_tui: bool) {
     );
 
     let err_fn = |e| {
+        #[cfg(unix)]
         error!("couldn't connect to journald: {}", e);
     };
 

--- a/crates/mirro-rs/src/dbg/mod.rs
+++ b/crates/mirro-rs/src/dbg/mod.rs
@@ -1,0 +1,12 @@
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+pub fn log() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "mirro_rs=debug".into()),
+        )
+        //    .with(tracing_subscriber::fmt::layer())
+        .with(tui_logger::tracing_subscriber_layer())
+        .init();
+}

--- a/crates/mirro-rs/src/dbg/mod.rs
+++ b/crates/mirro-rs/src/dbg/mod.rs
@@ -1,12 +1,41 @@
+use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-pub fn log() {
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "mirro_rs=debug".into()),
-        )
-        //    .with(tracing_subscriber::fmt::layer())
-        .with(tui_logger::tracing_subscriber_layer())
-        .init();
+pub fn log(skip_tui: bool) {
+    let registry = tracing_subscriber::registry().with(
+        tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| "mirro_rs=debug".into()),
+    );
+
+    let err_fn = |e| {
+        error!("couldn't connect to journald: {}", e);
+    };
+
+    match (tracing_journald::layer(), skip_tui) {
+        (Ok(layer), true) => {
+            registry
+                .with(layer)
+                .with(tracing_subscriber::fmt::layer())
+                .init();
+        }
+        // journald is typically available on Linux systems, but nowhere else. Portable software
+        // should handle its absence gracefully.
+        (Err(e), true) => {
+            registry.with(tracing_subscriber::fmt::layer()).init();
+            err_fn(e);
+        }
+        (Ok(layer), false) => {
+            registry
+                .with(layer)
+                .with(tui_logger::tracing_subscriber_layer())
+                .init();
+        }
+        (Err(e), false) => {
+            registry.with(tui_logger::tracing_subscriber_layer()).init();
+            err_fn(e);
+        }
+    }
+
+    let pkg_ver = env!("CARGO_PKG_VERSION");
+    info!(version = pkg_ver, "mirro-rs has started");
 }

--- a/crates/mirro-rs/src/direct/mod.rs
+++ b/crates/mirro-rs/src/direct/mod.rs
@@ -6,7 +6,7 @@ use archlinux::{
     get_client, ArchLinux, Mirror,
 };
 use itertools::Itertools;
-use log::error;
+use tracing::error;
 
 use crate::{
     cli::Protocol,

--- a/crates/mirro-rs/src/direct/mod.rs
+++ b/crates/mirro-rs/src/direct/mod.rs
@@ -6,7 +6,7 @@ use archlinux::{
     get_client, ArchLinux, Mirror,
 };
 use itertools::Itertools;
-use tracing::{error, info};
+use tracing::error;
 
 use crate::{
     cli::Protocol,

--- a/crates/mirro-rs/src/direct/mod.rs
+++ b/crates/mirro-rs/src/direct/mod.rs
@@ -6,7 +6,7 @@ use archlinux::{
     get_client, ArchLinux, Mirror,
 };
 use itertools::Itertools;
-use tracing::error;
+use tracing::{error, info};
 
 use crate::{
     cli::Protocol,
@@ -30,13 +30,13 @@ pub async fn begin(configuration: Configuration) -> Result<()> {
                 match result {
                     Ok(mirrors) => mirrors,
                     Err(e) => {
-                        eprintln!("{e}");
+                        error!("{e}");
                         get_new_mirrors(Arc::clone(&config), cache_file.as_ref()).await?
                     }
                 }
             }
             Err(e) => {
-                eprintln!("{e}");
+                error!("{e}");
                 get_new_mirrors(Arc::clone(&config), cache_file.as_ref()).await?
             }
         }
@@ -91,7 +91,7 @@ pub async fn begin(configuration: Configuration) -> Result<()> {
         .await
         .await
         {
-            eprintln!("{e}");
+            error!("{e}");
         }
     } else {
         IoAsyncHandler::write_to_file(outfile, &results, export_count as usize, None, None).await;

--- a/crates/mirro-rs/src/main.rs
+++ b/crates/mirro-rs/src/main.rs
@@ -8,12 +8,13 @@ mod tui;
 
 use std::sync::{Arc, Mutex};
 
+use tracing::error;
+
 #[cfg(any(feature = "json", feature = "toml", feature = "yaml"))]
 use self::config::watch_config;
 
 #[tokio::main]
 async fn main() {
-    dbg::log();
     let args = <cli::ArgConfig as clap::Parser>::parse();
 
     #[cfg(any(feature = "json", feature = "toml", feature = "yaml"))]
@@ -35,18 +36,11 @@ async fn main() {
     #[cfg(not(any(feature = "json", feature = "toml", feature = "yaml")))]
     let config = config::Configuration::from(args);
 
-    if config.direct {
-        #[cfg(target_os = "linux")]
-        {
-            if let Err(e) = systemd_journal_logger::JournalLog::new().unwrap().install() {
-                eprintln!("{e}");
-            } else {
-                //          log::set_max_level(log::LevelFilter::Info);
-            }
-        }
+    dbg::log(config.direct);
 
+    if config.direct {
         if let Err(e) = direct::begin(config).await {
-            eprintln!("{e}")
+            error!("{e}")
         }
     } else {
         let config = Arc::new(Mutex::new(config));

--- a/crates/mirro-rs/src/main.rs
+++ b/crates/mirro-rs/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod config;
+mod dbg;
 mod direct;
 #[cfg(test)]
 mod test;
@@ -12,6 +13,7 @@ use self::config::watch_config;
 
 #[tokio::main]
 async fn main() {
+    dbg::log();
     let args = <cli::ArgConfig as clap::Parser>::parse();
 
     #[cfg(any(feature = "json", feature = "toml", feature = "yaml"))]
@@ -39,7 +41,7 @@ async fn main() {
             if let Err(e) = systemd_journal_logger::JournalLog::new().unwrap().install() {
                 eprintln!("{e}");
             } else {
-                log::set_max_level(log::LevelFilter::Info);
+                //          log::set_max_level(log::LevelFilter::Info);
             }
         }
 

--- a/crates/mirro-rs/src/tui/inputs/event.rs
+++ b/crates/mirro-rs/src/tui/inputs/event.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use log::error;
+use tracing::error;
 
 use super::key::Key;
 use super::InputEvent;

--- a/crates/mirro-rs/src/tui/io/handler.rs
+++ b/crates/mirro-rs/src/tui/io/handler.rs
@@ -12,8 +12,8 @@ use std::{
 };
 
 use itertools::Itertools;
-use log::{error, info, warn};
 use tokio::sync::Mutex;
+use tracing::{error, info, warn};
 
 use crate::{
     config::Configuration,

--- a/crates/mirro-rs/src/tui/mod.rs
+++ b/crates/mirro-rs/src/tui/mod.rs
@@ -13,12 +13,12 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use log::{debug, LevelFilter};
 use std::{
     sync::{atomic::AtomicBool, Arc},
     time::Duration,
 };
 use tokio::sync::Mutex;
+use tracing::debug;
 
 use ratatui::{backend::CrosstermBackend, Terminal};
 
@@ -49,8 +49,8 @@ pub async fn start(configuration: Arc<std::sync::Mutex<Configuration>>) -> Resul
     let app = Arc::new(Mutex::new(App::new(sync_io_tx, Arc::clone(&configuration))));
     let inner = Arc::clone(&app);
 
-    tui_logger::init_logger(LevelFilter::Trace).unwrap();
-    tui_logger::set_default_level(log::LevelFilter::Debug);
+    //    tui_logger::init_logger(LevelFilter::Trace).unwrap();
+    //    tui_logger::set_default_level(log::LevelFilter::Debug);
 
     let popup_state = Arc::new(Mutex::new(PopUpState::new()));
     {

--- a/crates/mirro-rs/src/tui/mod.rs
+++ b/crates/mirro-rs/src/tui/mod.rs
@@ -49,9 +49,6 @@ pub async fn start(configuration: Arc<std::sync::Mutex<Configuration>>) -> Resul
     let app = Arc::new(Mutex::new(App::new(sync_io_tx, Arc::clone(&configuration))));
     let inner = Arc::clone(&app);
 
-    //    tui_logger::init_logger(LevelFilter::Trace).unwrap();
-    //    tui_logger::set_default_level(log::LevelFilter::Debug);
-
     let popup_state = Arc::new(Mutex::new(PopUpState::new()));
     {
         let popup_state = Arc::clone(&popup_state);

--- a/crates/mirro-rs/src/tui/state.rs
+++ b/crates/mirro-rs/src/tui/state.rs
@@ -10,11 +10,11 @@ use crate::{
 };
 
 use itertools::Itertools;
-use log::{error, info, warn};
 use ratatui::{
     style::{Color, Modifier, Style},
     widgets::{Cell, Row},
 };
+use tracing::{error, info, warn};
 use unicode_width::UnicodeWidthStr;
 
 use crate::tui::actions::Action;

--- a/crates/mirro-rs/src/tui/ui.rs
+++ b/crates/mirro-rs/src/tui/ui.rs
@@ -16,7 +16,7 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Cell, Clear, Gauge, Paragraph, Row, Table},
     Frame,
 };
-use tracing::info;
+use tracing::{debug, info, trace};
 use tui_logger::TuiLoggerWidget;
 
 use crate::cli::{Protocol, ViewSort};
@@ -152,7 +152,7 @@ pub fn ui(
             f.render_widget(Clear, area);
             if exporting.load(std::sync::atomic::Ordering::Relaxed) && rate_enabled {
                 while let Ok(pos) = percentage.try_recv() {
-                    info!("exporting mirrors: progress {pos:.2}%");
+                    debug!("exporting mirrors: progress {pos:.2}%");
                     let gauge = Gauge::default()
                         .gauge_style(Style::default().fg(Color::Blue).bg(Color::Black))
                         .block(create_block("Exporting mirrors"))

--- a/crates/mirro-rs/src/tui/ui.rs
+++ b/crates/mirro-rs/src/tui/ui.rs
@@ -16,7 +16,7 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Cell, Clear, Gauge, Paragraph, Row, Table},
     Frame,
 };
-use tracing::{debug, info, trace};
+use tracing::debug;
 use tui_logger::TuiLoggerWidget;
 
 use crate::cli::{Protocol, ViewSort};

--- a/crates/mirro-rs/src/tui/ui.rs
+++ b/crates/mirro-rs/src/tui/ui.rs
@@ -16,6 +16,7 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Cell, Clear, Gauge, Paragraph, Row, Table},
     Frame,
 };
+use tracing::info;
 use tui_logger::TuiLoggerWidget;
 
 use crate::cli::{Protocol, ViewSort};
@@ -151,7 +152,7 @@ pub fn ui(
             f.render_widget(Clear, area);
             if exporting.load(std::sync::atomic::Ordering::Relaxed) && rate_enabled {
                 while let Ok(pos) = percentage.try_recv() {
-                    log::info!("exporting mirrors: progress {pos:.2}%");
+                    info!("exporting mirrors: progress {pos:.2}%");
                     let gauge = Gauge::default()
                         .gauge_style(Style::default().fg(Color::Blue).bg(Color::Black))
                         .block(create_block("Exporting mirrors"))


### PR DESCRIPTION
Mainly for a structured way to control where we emit logs depending on the state of the application. 

We'd still like stdout (and journal, if applicable) logs if TUI is skipped